### PR TITLE
Use transient for dry-run results

### DIFF
--- a/includes/class-wp2etos.php
+++ b/includes/class-wp2etos.php
@@ -85,11 +85,9 @@ class WP2ETOS {
             }
         }
 
-        // Dry run request
-        $dry_result = null;
-        if ( isset($_POST['dry_run']) && check_admin_referer( 'wp2etos_at_run', 'wp2etos_nonce3' ) ){
-            $dry_result = $this->collect_products_and_terms(true);
-        }
+        // Retrieve dry-run result from transient if available
+        $dry_result = get_transient( 'wp2etos_at_dryrun' );
+        delete_transient( 'wp2etos_at_dryrun' );
 
         ?>
         <div class="wrap">


### PR DESCRIPTION
## Summary
- Retrieve dry-run preview data from the `wp2etos_at_dryrun` transient and delete it after reading

## Testing
- `php -l includes/class-wp2etos.php`


------
https://chatgpt.com/codex/tasks/task_e_68b9baaab6f483279ca95cda35fbb661