### PR TITLE
Add debug logging for queued product terms

### DIFF
--- a/includes/class-wp2etos.php
+++ b/includes/class-wp2etos.php
@@ -312,6 +312,17 @@ class WP2ETOS {
         } else {
             $this->worker_sync_product( $pid, $terms, $hash );
         }
+
+        if ( defined( 'WP_DEBUG_LOG' ) && WP_DEBUG_LOG ) {
+            if ( count( $terms ) <= 20 ) {
+                $msg = sprintf(
+                    '[WP2ETOS] product %d queued with terms: %s',
+                    $pid,
+                    implode( ', ', $terms )
+                );
+                error_log( $msg );
+            }
+        }
     }
 
     /** Worker: create terms & attach attribute (visible=1, variation=0) */


### PR DESCRIPTION
## Summary
- log queued products and terms when WP_DEBUG_LOG is enabled and the term count is small

## Testing
- `php -l includes/class-wp2etos.php`


------
https://chatgpt.com/codex/tasks/task_e_68ba7140cad48327a73eede003ff4b0d