### PR TITLE
Add debug logging for recent sync run

### DIFF
--- a/wp2etos.php
+++ b/wp2etos.php
@@ -12,6 +12,13 @@
 
 if ( ! defined( 'ABSPATH' ) ) { exit; }
 
+if ( ! defined( 'WP_DEBUG' ) ) {
+    define( 'WP_DEBUG', true );
+}
+if ( ! defined( 'WP_DEBUG_LOG' ) ) {
+    define( 'WP_DEBUG_LOG', true );
+}
+
 define( 'WP2ETOS_AT_VERSION', '1.0.0' );
 define( 'WP2ETOS_AT_SLUG', 'wp2etos' );
 define( 'WP2ETOS_AT_OPTION', 'wp2etos_at_options' );


### PR DESCRIPTION
## Summary
- Log details of recently queued products, new terms, and associations during scheduled syncs when WP_DEBUG_LOG is enabled.
- Ensure WP_DEBUG and WP_DEBUG_LOG constants are defined so messages appear in `wp-content/debug.log`.
- Refactor collection logic to support detailed logging and summaries.

## Testing
- `php -l wp2etos.php`
- `php -l includes/class-wp2etos.php`


------
https://chatgpt.com/codex/tasks/task_e_68ba71d0a6a48327a5a72d640f9a4bc8