### PR TITLE
Log cron trigger and summary in sync_recent

### DIFF
--- a/includes/class-wp2etos.php
+++ b/includes/class-wp2etos.php
@@ -396,6 +396,10 @@ class WP2ETOS {
 
     /** Fallback scheduled task: sync recently modified products */
     public function sync_recent(){
+        if ( defined( 'WP_DEBUG_LOG' ) && WP_DEBUG_LOG ) {
+            error_log( '[WP2ETOS] cron 15min trigger' );
+        }
+
         $last = (int) get_option( 'wp2etos_sync_recent_ts', 0 );
         update_option( 'wp2etos_sync_recent_ts', time() );
 


### PR DESCRIPTION
## Summary
- Log when the 15-minute cron executes via `error_log` when debug logging is on.
- Preserve summary logging of queued products, new terms, and associations after processing.

## Testing
- `php -l includes/class-wp2etos.php`


------
https://chatgpt.com/codex/tasks/task_e_68ba7451ecd883278a68e31c9c8e9e80