### PR TITLE
Make collect products callable from hooks

### DIFF
--- a/includes/class-woo2etos.php
+++ b/includes/class-woo2etos.php
@@ -338,7 +338,7 @@ class Woo2Etos {
     }
 
     /** Find products and for each compute terms; optionally schedule jobs */
-    private function collect_products_and_terms( $dry = true, $since = 0, $page = 1 ){
+    public function collect_products_and_terms( $dry = true, $since = 0, $page = 1 ){
         if ( $dry ) {
             $products = array();
             $all_terms = array();


### PR DESCRIPTION
## Summary
- Expose `collect_products_and_terms` as a public method so `woo2etos_collect_products` action can call it

## Testing
- `php -l includes/class-woo2etos.php`


------
https://chatgpt.com/codex/tasks/task_e_68bad0b035108327a4d72e0660ddfb1e